### PR TITLE
Fixed BlockAligning adding incorrect amount of trailing 9's

### DIFF
--- a/src/main/java/com/afrunt/jach/logic/ACHWriter.java
+++ b/src/main/java/com/afrunt/jach/logic/ACHWriter.java
@@ -82,7 +82,8 @@ public class ACHWriter extends ACHProcessor {
             if (lines % 10 != 0 && blockAligning) {
                 String emptyLine = new String(new char[ACHRecord.ACH_RECORD_LENGTH]).replace("\0", "9");
                 writer.write(LINE_SEPARATOR);
-                for (int i = 0; i < 10 - (lines % 10) - 1; i++) {
+                int trailingLinesLeft = 10 - (lines % 10) - 1;
+                for (int i = 0; i < trailingLinesLeft; i++) {
                     writeLine(writer, emptyLine);
                 }
 

--- a/src/test/java/com/afrunt/jach/test/ACHTest.java
+++ b/src/test/java/com/afrunt/jach/test/ACHTest.java
@@ -61,6 +61,11 @@ public class ACHTest {
         String out = ach.write(document);
         String[] strings = out.split(ACH.LINE_SEPARATOR);
         Assert.assertEquals(10, strings.length);
+
+        document = ach.read(getClass().getClassLoader().getResourceAsStream("ach-pos.txt"));
+        out = ach.write(document);
+        strings = out.split(ACH.LINE_SEPARATOR);
+        Assert.assertEquals(10, strings.length);
     }
 
     private void testFilesAreEquals(InputStream is1, InputStream is2) {


### PR DESCRIPTION
Fixed BlockAligning adding incorrect amount of trailing 9's

- Amended unit test to check ach-post example and ensure the total lines are the expected 10 lines