### PR TITLE
Correct usage of rank for partial tag match

### DIFF
--- a/src/main/java/com/afrunt/jach/logic/ACHReader.java
+++ b/src/main/java/com/afrunt/jach/logic/ACHReader.java
@@ -186,7 +186,7 @@ public class ACHReader extends ACHProcessor {
             ++i;
         }
 
-        return rank;
+        return rank == achTypeTagsMetadata.size() ? rank : 0;
     }
 
     private int rankField(String value, ACHFieldMetadata fieldMetadata) {


### PR DESCRIPTION
This corrects issue #14 -- Ambiguous BatchHeader types found during ACH request reading