### PR TITLE
Adds support for REM transaction type code

### DIFF
--- a/src/main/java/com/afrunt/jach/domain/addenda/iat/FirstIATAddendaRecord.java
+++ b/src/main/java/com/afrunt/jach/domain/addenda/iat/FirstIATAddendaRecord.java
@@ -61,7 +61,8 @@ public class FirstIATAddendaRecord extends IATAddendaRecord {
      * Describes the type of payment:
      * <p>
      * ANN = Annuity
-     * BUS = Business/Commercial DEP = Deposit
+     * BUS = Business/Commercial
+     * DEP = Deposit
      * LOA = Loan
      * MIS = Miscellaneous
      * MOR = Mortgage
@@ -80,7 +81,7 @@ public class FirstIATAddendaRecord extends IATAddendaRecord {
      * @return type of payment
      */
     @ACHField(start = 3, length = 3, name = TRANSACTION_TYPE_CODE, inclusion = REQUIRED, values = {
-            "ANN", "BUS", "DEP", "LOA", "MIS", "MOR", "PEN", "RLS", "SAL", "TAX", "TEL", "WEB", "ARC", "BOC", "POP", "RCK"
+            "ANN", "BUS", "DEP", "LOA", "MIS", "MOR", "PEN", "RLS", "REM", "SAL", "TAX", "TEL", "WEB", "ARC", "BOC", "POP", "RCK"
     })
     public String getTransactionTypeCode() {
         return transactionTypeCode;


### PR DESCRIPTION
Adds support for the `REM` transaction type code in `IAT` transactions.
Looks like it was just omitted from the values list, as it is already included in the javadoc.