### PR TITLE
Validation of constant values fail if case differs

### DIFF
--- a/src/main/java/com/afrunt/jach/metadata/ACHFieldMetadata.java
+++ b/src/main/java/com/afrunt/jach/metadata/ACHFieldMetadata.java
@@ -100,7 +100,12 @@ public class ACHFieldMetadata extends FieldMetadata implements Comparable<ACHFie
             if (isAnnotatedWith(Values.class)) {
                 values = Arrays.asList(getAnnotation(Values.class).value());
             } else {
-                values = Arrays.asList(achAnnotation().values());
+                values = new ArrayList<String>(Arrays.asList(achAnnotation().values())) {
+                	@Override
+                    public int indexOf(Object o) {
+                		return super.indexOf(((String)o).toUpperCase());
+                    }
+                };
             }
         }
 


### PR DESCRIPTION
The Fed seems to be okay with lowercase values for items, such as files using IAT transaction type code 'mis' even though documentation lists 'MIS'.  All documentation I've seen cites upper case only, but the documentation itself does not specify if upper case is required, and the Fed itself doesn't reject files using lowercase, so I must assume they're okay.

I'm open to other ways to fix this.  I figured this would address the issue in any possible logic with any possible object, which potentially is overreaching.  Perhaps I should've included this for classes using @Values, too.